### PR TITLE
記事に対するサムネイル画像設定を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ i/tmp
 
 # Server process ID files
 *.pid
+
+/tmp
+/public/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,10 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
+# For thumbnail uploader
+gem 'carrierwave'
+gem 'carrierwave-mongoid'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,15 @@ GEM
     bson (4.0.3)
     builder (3.2.2)
     byebug (8.2.2)
+    carrierwave (0.10.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
+    carrierwave-mongoid (0.8.1)
+      carrierwave (>= 0.8.0, < 0.11.0)
+      mongoid (>= 3.0, < 6.0)
+      mongoid-grid_fs (>= 1.3, < 3.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -78,6 +87,9 @@ GEM
       mongo (~> 2.1)
       origin (~> 2.2)
       tzinfo (>= 0.3.37)
+    mongoid-grid_fs (2.2.1)
+      mime-types (>= 1.0, < 3.0)
+      mongoid (>= 3.0, < 6.0)
     multi_json (1.11.2)
     mysql2 (0.4.3)
     nokogiri (1.6.7.2)
@@ -152,6 +164,8 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
+  carrierwave-mongoid
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :set_article, only: [:show, :edit, :update, :destroy]
+  before_action :set_article, only: [:show, :edit, :update, :destroy, :thumbnail]
 
   # GET /articles
   # GET /articles.json
@@ -58,6 +58,15 @@ class ArticlesController < ApplicationController
     respond_to do |format|
       format.html { redirect_to articles_url, notice: 'Article was successfully destroyed.' }
       format.json { head :no_content }
+    end
+  end
+
+  def thumbnail
+    content = @article.thumbnail.read
+
+    if stale?(etag: content, last_modified: @article.updated_at.utc, public: true)
+      send_data content, type: @article.thumbnail.file.content_type, disposition: "inline"
+      expires_in 0, public: true
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -69,6 +69,6 @@ class ArticlesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def article_params
-      params.require(:article).permit(:title, :body, :published_at, :category_id)
+      params.require(:article).permit(:title, :body, :published_at, :category_id, :thumbnail)
     end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,6 @@
 class Article < ActiveRecord::Base
   belongs_to :category, required: true
-  attr_accessor :title, :body
+  attr_accessor :title, :body, :thumbnail
 
   validates :title, presence: true
   validates :body, presence: true
@@ -13,10 +13,12 @@ class Article < ActiveRecord::Base
   def create_mongo_collections
     self.title_oid = Content.create!(body: title, type: 'article_title').id
     self.body_oid = Content.create!(body: body, type: 'article_body').id
+    self.thumbnail_oid = Thumbnail.create!(image: thumbnail).id
   end
 
   def fetch_mongo_data
     self.title = Content.find(title_oid).body
     self.body = Content.find(body_oid).body
+    self.thumbnail = Thumbnail.find(thumbnail_oid).image if thumbnail_oid
   end
 end

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -1,4 +1,7 @@
 class Thumbnail
   include Mongoid::Document
+  field :image, type: String
   mount_uploader :image, ThumbnailUploader
+
+  validates :image, presence: true
 end

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -1,0 +1,4 @@
+class Thumbnail
+  include Mongoid::Document
+  mount_uploader :image, ThumbnailUploader
+end

--- a/app/uploaders/thumbnail_uploader.rb
+++ b/app/uploaders/thumbnail_uploader.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+class ThumbnailUploader < CarrierWave::Uploader::Base
+
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :grid_fs
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process :scale => [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process :resize_to_fit => [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_white_list
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+
+end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -21,6 +21,9 @@
     <%= f.collection_select :category_id, Category.all, :id, :name, prompt: true %>
   </div>
   <div>
+    <%= f.file_field :thumbnail %>
+  </div>
+  <div>
     <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,5 +1,12 @@
 <h1>articles#show</h1>
 <dl>
+  <dt>サムネイル</dt>
+  <dd>
+    <% if @article.thumbnail %>
+      <%= image_tag thumbnail_article_path(@article), width: "200px" %></dd>
+    <% else %>
+      No Image
+    <% end %>
   <dt>タイトル</dt>
   <dd><%= @article.title %></dd>
   <dt>コンテンツ</dt>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  resources :articles
+  resources :articles do
+    member do
+      get 'thumbnail'
+    end
+  end
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20160308123047_add_thumbnail_oid_to_articles.rb
+++ b/db/migrate/20160308123047_add_thumbnail_oid_to_articles.rb
@@ -1,0 +1,5 @@
+class AddThumbnailOidToArticles < ActiveRecord::Migration
+  def change
+    add_column :articles, :thumbnail_oid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160303211449) do
+ActiveRecord::Schema.define(version: 20160308123047) do
 
   create_table "articles", force: :cascade do |t|
-    t.string   "title_oid",    limit: 255, null: false
-    t.string   "body_oid",     limit: 255, null: false
+    t.string   "title_oid",     limit: 255, null: false
+    t.string   "body_oid",      limit: 255, null: false
     t.datetime "published_at"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.integer  "category_id",  limit: 4,   null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "category_id",   limit: 4,   null: false
+    t.string   "thumbnail_oid", limit: 255
   end
 
   add_index "articles", ["category_id"], name: "index_articles_on_category_id", using: :btree


### PR DESCRIPTION
For issue #17 

PR #18 の変更箇所について 
## ルーティング

記事に関連付けられたサムネイル画像を取得するためのルーティング `GET /articles/:id/thumbnail` を追加
## コントローラ

上記のルーティングを処理するアクションメソッドを追加。GridFS に格納されたサムネイル画像を取得し、画像のバイナリデータを返す
## モデル

サムネイル画像を扱うためのコレクションを新しく追加
### Thumbnail モデル (MongoDB)

| 型 | 属性名 | 役割 |
| --- | --- | --- |
| ObjectID | _id | サムネイル画像を一意に特定する ID |
| string | image | サムネイル画像のファイル名 (carrierwave でマウントする属性) |
### Article モデル (MySQL)

記事からサムネイル画像を参照するために以下の属性を Article モデルに追加

| 型 | 属性名 | 役割 |
| --- | --- | --- |
| string | thumbnail_oid | サムネイル画像を一意に特定する ObjectID |
